### PR TITLE
Add highlighting for single quotes and booleans

### DIFF
--- a/syntaxes/brackets-json.tmLanguage.json
+++ b/syntaxes/brackets-json.tmLanguage.json
@@ -10,8 +10,16 @@
       "match": "\"(?:[^\"\\\\]|\\\\.)*\""
     },
     {
+      "name": "string.quoted.single.json",
+      "match": "'(?:[^'\\\\]|\\\\.)*'"
+    },
+    {
       "name": "constant.numeric.json",
       "match": "-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
+    },
+    {
+      "name": "constant.language.json",
+      "match": "\\b(?:true|false|null)\\b"
     }
   ]
 }

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -32,3 +32,35 @@ test('tokenize square brackets, strings and numbers', async () => {
   expect(scopes).toContain('string.quoted.double.json');
   expect(scopes).toContain('constant.numeric.json');
 });
+
+test('tokenize single quoted strings', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = "['bar']";
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('string.quoted.single.json');
+});
+
+test('tokenize boolean and null literals', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '[true, false, null]';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('constant.language.json');
+});


### PR DESCRIPTION
## Summary
- highlight single quoted strings
- highlight the literal values `true`, `false`, and `null`
- test single quoted, boolean, and null tokens

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6854777987408325a6dfa82078ba2033