### PR TITLE
Add separator and hex highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,21 @@
         "configuration": "./language-configuration.json"
       }
     ],
-    "grammars": [
-      {
-        "language": "brackets-json",
-        "scopeName": "source.brackets-json",
-        "path": "./syntaxes/brackets-json.tmLanguage.json"
-      }
-    ]
-  },
+      "grammars": [
+        {
+          "language": "brackets-json",
+          "scopeName": "source.brackets-json",
+          "path": "./syntaxes/brackets-json.tmLanguage.json"
+        }
+      ],
+      "themes": [
+        {
+          "label": "Brackets JSON Theme",
+          "uiTheme": "vs-dark",
+          "path": "./themes/brackets-json-color-theme.json"
+        }
+      ]
+    },
   "devDependencies": {
     "@types/jest": "^29.0.0",
     "@types/vscode": "^1.75.0",

--- a/syntaxes/brackets-json.tmLanguage.json
+++ b/syntaxes/brackets-json.tmLanguage.json
@@ -6,6 +6,14 @@
       "match": "\\[|\\]"
     },
     {
+      "name": "punctuation.separator.json",
+      "match": "[,;:]"
+    },
+    {
+      "name": "constant.numeric.hex.json",
+      "match": "h'(?:[0-9a-fA-F]+)'"
+    },
+    {
       "name": "string.quoted.double.json",
       "match": "\"(?:[^\"\\\\]|\\\\.)*\""
     },

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -64,3 +64,35 @@ test('tokenize boolean and null literals', async () => {
   const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
   expect(scopes).toContain('constant.language.json');
 });
+
+test('tokenize separator punctuation', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '[1,2:3;]';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('punctuation.separator.json');
+});
+
+test('tokenize hex literals', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = "[h'1a2b']";
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('constant.numeric.hex.json');
+});

--- a/themes/brackets-json-color-theme.json
+++ b/themes/brackets-json-color-theme.json
@@ -1,0 +1,23 @@
+{
+  "name": "Brackets JSON Theme",
+  "type": "dark",
+  "colors": {},
+  "tokenColors": [
+    {
+      "scope": "string.quoted.double.json",
+      "settings": { "foreground": "#CE9178" }
+    },
+    {
+      "scope": "string.quoted.single.json",
+      "settings": { "foreground": "#D7BA7D" }
+    },
+    {
+      "scope": "constant.numeric.hex.json",
+      "settings": { "foreground": "#4EC9B0" }
+    },
+    {
+      "scope": "punctuation.separator.json",
+      "settings": { "foreground": "#C586C0" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- highlight separator punctuation
- distinguish single-quoted vs double-quoted strings in theme
- highlight hex literals of the form `h'ABCD'`
- add color theme and register it
- test new grammar rules

## Testing
- `npm test`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_68547a0e0dec83258e52574edcfc3885