### PR TITLE
Add theme colors for all syntax categories

### DIFF
--- a/themes/brackets-json-color-theme.json
+++ b/themes/brackets-json-color-theme.json
@@ -18,6 +18,18 @@
     {
       "scope": "punctuation.separator.json",
       "settings": { "foreground": "#C586C0" }
+    },
+    {
+      "scope": "punctuation.square.brackets.json",
+      "settings": { "foreground": "#D4D4D4" }
+    },
+    {
+      "scope": "constant.numeric.json",
+      "settings": { "foreground": "#B5CEA8" }
+    },
+    {
+      "scope": "constant.language.json",
+      "settings": { "foreground": "#569CD6" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add missing token colors for square brackets, numbers, and language literals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68547bf0f25c8325b818322bebae886c