### PR TITLE
Add barewords, atwords, comments and regex highlights

### DIFF
--- a/syntaxes/brackets-json.tmLanguage.json
+++ b/syntaxes/brackets-json.tmLanguage.json
@@ -2,6 +2,18 @@
   "scopeName": "source.brackets-json",
   "patterns": [
     {
+      "name": "string.regexp.json",
+      "match": "\\(\\s*/(?:[^\\\\/]|\\\\.)+/[a-zA-Z]*\\s*\\)"
+    },
+    {
+      "name": "comment.block.inline.json",
+      "match": "(?<!\\()\\/[^\\n]*?\\/(?![a-zA-Z])"
+    },
+    {
+      "name": "comment.line.number-sign.json",
+      "match": "#.*$"
+    },
+    {
       "name": "punctuation.square.brackets.json",
       "match": "\\[|\\]"
     },
@@ -28,6 +40,14 @@
     {
       "name": "constant.language.json",
       "match": "\\b(?:true|false|null)\\b"
+    },
+    {
+      "name": "keyword.other.atword.json",
+      "match": "@[A-Za-z_][A-Za-z0-9_]*"
+    },
+    {
+      "name": "identifier.bareword.json",
+      "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
     }
   ]
 }

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -96,3 +96,83 @@ test('tokenize hex literals', async () => {
   const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
   expect(scopes).toContain('constant.numeric.hex.json');
 });
+
+test('tokenize at-words', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '@word';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('keyword.other.atword.json');
+});
+
+test('tokenize bare words', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = 'bareWord';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('identifier.bareword.json');
+});
+
+test('tokenize inline comments', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '/ inline comment /';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('comment.block.inline.json');
+});
+
+test('tokenize end of line comments', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '# end';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('comment.line.number-sign.json');
+});
+
+test('tokenize regex literals', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '(/reg\\/ex/abc)';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('string.regexp.json');
+});

--- a/themes/brackets-json-color-theme.json
+++ b/themes/brackets-json-color-theme.json
@@ -30,6 +30,22 @@
     {
       "scope": "constant.language.json",
       "settings": { "foreground": "#9e87d0" }
+    },
+    {
+      "scope": "keyword.other.atword.json",
+      "settings": { "foreground": "#c586c0" }
+    },
+    {
+      "scope": "identifier.bareword.json",
+      "settings": { "foreground": "#569cd6" }
+    },
+    {
+      "scope": ["comment.line.number-sign.json", "comment.block.inline.json"],
+      "settings": { "foreground": "#606060" }
+    },
+    {
+      "scope": "string.regexp.json",
+      "settings": { "foreground": "#ce9178" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- recognize regexes and word forms in grammar
- colorize new token scopes in theme
- test new syntax tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685481b43cc88325940c045ef9d8c957