### PR TITLE
Add ISO date/time and hex number patterns

### DIFF
--- a/syntaxes/brackets-json.tmLanguage.json
+++ b/syntaxes/brackets-json.tmLanguage.json
@@ -34,6 +34,14 @@
       "match": "'(?:[^'\\\\]|\\\\.)*'"
     },
     {
+      "name": "constant.numeric.date.json",
+      "match": "\\b\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}Z?)?\\b"
+    },
+    {
+      "name": "constant.numeric.json",
+      "match": "\\b[0-9]*[a-fA-F][0-9a-fA-F]*\\b"
+    },
+    {
       "name": "constant.numeric.json",
       "match": "-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
     },

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -176,3 +176,35 @@ test('tokenize regex literals', async () => {
   const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
   expect(scopes).toContain('string.regexp.json');
 });
+
+test('tokenize ISO-8601 dates and date/time literals', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '[2025-06-19, 2025-06-19T21:57:12Z]';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('constant.numeric.date.json');
+});
+
+test('tokenize bare hex numbers', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = '[4676635a]';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('constant.numeric.json');
+});


### PR DESCRIPTION
## Summary
- add pattern for ISO-8601 dates and date/time literals
- treat bare hexadecimal digit sequences as numbers
- test highlighting for new literals

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685488ddd20883258cf876062e9b451d