### PR TITLE
Add UR literal and keyword highlighting

### DIFF
--- a/syntaxes/brackets-json.tmLanguage.json
+++ b/syntaxes/brackets-json.tmLanguage.json
@@ -50,6 +50,14 @@
       "match": "\\b(?:true|false|null)\\b"
     },
     {
+      "name": "keyword.other.literal.json",
+      "match": "\\b(?:ELIDED|ENCRYPTED|COMPRESSED)\\b"
+    },
+    {
+      "name": "constant.other.ur.json",
+      "match": "(?i)ur:[a-z][a-z0-9-]*/[a-z]+"
+    },
+    {
       "name": "keyword.other.atword.json",
       "match": "@[A-Za-z_][A-Za-z0-9_]*"
     },

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -208,3 +208,35 @@ test('tokenize bare hex numbers', async () => {
   const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
   expect(scopes).toContain('constant.numeric.json');
 });
+
+test('tokenize UR literals', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = 'ur:envelope/abcd';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('constant.other.ur.json');
+});
+
+test('tokenize keywords', async () => {
+  const grammarPath = path.join(__dirname, '..', 'syntaxes', 'brackets-json.tmLanguage.json');
+  const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async () => JSON.parse(grammarContent)
+  });
+  const grammar = await registry.loadGrammar('source.brackets-json');
+  if (!grammar) throw new Error('Grammar failed to load');
+
+  const line = 'ELIDED ENCRYPTED COMPRESSED';
+  const { tokens } = grammar.tokenizeLine(line, INITIAL);
+  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  expect(scopes).toContain('keyword.other.literal.json');
+});

--- a/themes/brackets-json-color-theme.json
+++ b/themes/brackets-json-color-theme.json
@@ -32,6 +32,14 @@
       "settings": { "foreground": "#9e87d0" }
     },
     {
+      "scope": "keyword.other.literal.json",
+      "settings": { "foreground": "#d16969" }
+    },
+    {
+      "scope": "constant.other.ur.json",
+      "settings": { "foreground": "#b5cea8" }
+    },
+    {
       "scope": "keyword.other.atword.json",
       "settings": { "foreground": "#c586c0" }
     },


### PR DESCRIPTION
## Summary
- highlight UR literals in grammar with a new scope
- add keyword highlighting for ELIDED, ENCRYPTED, and COMPRESSED
- color the new tokens in the theme file
- test UR literal and keyword tokenization

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548e53d7b083259254c68eb079494f