### PR TITLE
Fix highlight compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 See `README.md` for general information about the extension.
 
 Coding agents can use this file as a scratch pad and to report on progress.
+\nUpdated grammar and themes to support base theme inclusion and maintain highlighting across languages.

--- a/syntaxes/dcbor-envelope.tmLanguage.json
+++ b/syntaxes/dcbor-envelope.tmLanguage.json
@@ -1,52 +1,52 @@
 {
   "scopeName": "source.dcbor-envelope",
-  "patterns": [
+    "patterns": [
     {
-      "name": "comment.block.inline.dcbor",
+      "name": "comment.block.inline.dcbor comment.block",
       "match": "(?<!\\()\\/[^\\n]*?\\/(?![a-zA-Z])"
     },
     {
-      "name": "comment.line.number-sign.dcbor",
+      "name": "comment.line.number-sign.dcbor comment.line.number-sign",
       "match": "#.*$"
     },
     {
-      "name": "comment.line.ellipsis.dcbor",
+      "name": "comment.line.ellipsis.dcbor comment.line",
       "match": "\\.\\.\\.|…"
     },
     {
-      "name": "punctuation.square.brackets.dcbor",
+      "name": "punctuation.square.brackets.dcbor punctuation.definition.brackets",
       "match": "\\[|\\]"
     },
     {
-      "name": "punctuation.curly.braces.dcbor",
+      "name": "punctuation.curly.braces.dcbor punctuation.definition.braces",
       "match": "\\{|\\}"
     },
     {
-      "name": "punctuation.parenthesis.dcbor",
+      "name": "punctuation.parenthesis.dcbor punctuation.definition.parenthesis",
       "match": "\\(|\\)"
     },
     {
-      "name": "punctuation.angle.brackets.double.dcbor",
+      "name": "punctuation.angle.brackets.double.dcbor punctuation.definition.angle",
       "match": "<<|>>"
     },
     {
-      "name": "punctuation.angle.brackets.guillemet.dcbor",
+      "name": "punctuation.angle.brackets.guillemet.dcbor punctuation.definition.angle",
       "match": "«|»"
     },
     {
-      "name": "punctuation.angle.brackets.floral.dcbor",
+      "name": "punctuation.angle.brackets.floral.dcbor punctuation.definition.angle",
       "match": "❰|❱"
     },
     {
-      "name": "punctuation.separator.dcbor",
+      "name": "punctuation.separator.dcbor punctuation.separator",
       "match": "[,;:]"
     },
     {
-      "name": "string.quoted.prefixed.dcbor",
+      "name": "string.quoted.prefixed.dcbor string.quoted.single",
       "match": "[a-zA-Z]?[a-zA-Z0-9]+'(?:[^'\\\\]|\\\\.)*'"
     },
     {
-      "name": "string.quoted.prefixed.multiline.dcbor",
+      "name": "string.quoted.prefixed.multiline.dcbor string.quoted.single",
       "begin": "[a-zA-Z]?[a-zA-Z0-9]+'",
       "end": "'",
       "patterns": [
@@ -61,63 +61,63 @@
       ]
     },
     {
-      "name": "string.quoted.double.dcbor",
+      "name": "string.quoted.double.dcbor string.quoted.double",
       "match": "\"(?:[^\"\\\\]|\\\\.)*\""
     },
     {
-      "name": "string.quoted.single.dcbor",
+      "name": "string.quoted.single.dcbor string.quoted.single",
       "match": "'(?:[^'\\\\]|\\\\.)*'"
     },
     {
-      "name": "constant.numeric.date.dcbor",
+      "name": "constant.numeric.date.dcbor constant.numeric",
       "match": "\\b\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}Z?)?\\b"
     },
     {
-      "name": "constant.numeric.hex.dcbor",
+      "name": "constant.numeric.hex.dcbor constant.numeric.hex",
       "match": "\\b0[xX]([0-9a-fA-F]+)(\\.[0-9a-fA-F]+)?[pP][+-]?[0-9]+\\b"
     },
     {
-      "name": "constant.numeric.hex.dcbor",
+      "name": "constant.numeric.hex.dcbor constant.numeric.hex",
       "match": "\\b0[xX][0-9a-fA-F]+\\b"
     },
     {
-      "name": "constant.numeric.binary.dcbor",
+      "name": "constant.numeric.binary.dcbor constant.numeric",
       "match": "\\b0[bB][01]+\\b"
     },
     {
-      "name": "constant.numeric.octal.dcbor",
+      "name": "constant.numeric.octal.dcbor constant.numeric.octal",
       "match": "\\b0[oO][0-7]+\\b"
     },
     {
-      "name": "constant.numeric.dcbor",
+      "name": "constant.numeric.dcbor constant.numeric",
       "match": "\\b[0-9]*[a-fA-F][0-9a-fA-F]*\\b"
     },
     {
-      "name": "constant.numeric.special.dcbor",
+      "name": "constant.numeric.special.dcbor constant.numeric",
       "match": "-Infinity|Infinity|NaN"
     },
     {
-      "name": "constant.numeric.dcbor",
+      "name": "constant.numeric.dcbor constant.numeric",
       "match": "-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
     },
     {
-      "name": "constant.language.dcbor",
+      "name": "constant.language.dcbor constant.language",
       "match": "\\b(?:true|false|null|undefined|simple)\\b"
     },
     {
-      "name": "keyword.other.envcase.dcbor",
+      "name": "keyword.other.envcase.dcbor keyword.other",
       "match": "\\b(?:ELIDED|ENCRYPTED|COMPRESSED|NODE|WRAPPED|ASSERTION)\\b"
     },
     {
-      "name": "constant.other.ur.dcbor",
+      "name": "constant.other.ur.dcbor constant.other",
       "match": "(?i)ur:[a-z][a-z0-9-]*/[a-z]+"
     },
     {
-      "name": "constant.other.unit.dcbor",
+      "name": "constant.other.unit.dcbor constant.other",
       "match": "\\bUnit\\b"
     },
     {
-      "name": "identifier.bareword.dcbor",
+      "name": "identifier.bareword.dcbor identifier",
       "match": "\\b[A-Za-z_][A-Za-z0-9_-]*\\b"
     }
   ]

--- a/test/grammar.test.ts
+++ b/test/grammar.test.ts
@@ -27,7 +27,7 @@ test('tokenize square brackets, strings and numbers', async () => {
 
   const line = '["foo", 123]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('punctuation.square.brackets.dcbor');
   expect(scopes).toContain('string.quoted.double.dcbor');
   expect(scopes).toContain('constant.numeric.dcbor');
@@ -45,7 +45,7 @@ test('tokenize single quoted strings', async () => {
 
   const line = "['bar']";
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('string.quoted.single.dcbor');
 });
 
@@ -61,7 +61,7 @@ test('tokenize double angle brackets', async () => {
 
   const line = "<<test>>";
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('punctuation.angle.brackets.double.dcbor');
 });
 
@@ -77,7 +77,7 @@ test('tokenize guillemet brackets', async () => {
 
   const line = "«test»";
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('punctuation.angle.brackets.guillemet.dcbor');
 });
 
@@ -93,7 +93,7 @@ test('tokenize floral brackets', async () => {
 
   const line = "❰test❱";
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('punctuation.angle.brackets.floral.dcbor');
 });
 
@@ -109,7 +109,7 @@ test('tokenize boolean and null literals', async () => {
 
   const line = '[true, false, null]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('constant.language.dcbor');
 });
 
@@ -125,7 +125,7 @@ test('tokenize separator punctuation', async () => {
 
   const line = '[1,2:3;]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('punctuation.separator.dcbor');
 });
 
@@ -149,7 +149,7 @@ test('tokenize prefixed string literals', async () => {
 
   for (const line of examples) {
     const { tokens } = grammar.tokenizeLine(line, INITIAL);
-    const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+    const scopes = tokens.flatMap(t => t.scopes);
     expect(scopes.some(scope =>
       scope === 'string.quoted.prefixed.dcbor' ||
       scope === 'string.quoted.prefixed.multiline.dcbor'
@@ -169,7 +169,7 @@ test('tokenize bare words', async () => {
 
   const line = 'bareWord';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('identifier.bareword.dcbor');
 });
 
@@ -185,7 +185,7 @@ test('tokenize inline comments', async () => {
 
   const line = '/ inline comment /';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('comment.block.inline.dcbor');
 });
 
@@ -201,7 +201,7 @@ test('tokenize end of line comments', async () => {
 
   const line = '# end';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('comment.line.number-sign.dcbor');
 });
 
@@ -217,7 +217,7 @@ test('tokenize ISO-8601 dates and date/time literals', async () => {
 
   const line = '[2025-06-19, 2025-06-19T21:57:12Z]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('constant.numeric.date.dcbor');
 });
 
@@ -233,7 +233,7 @@ test('tokenize bare hex numbers', async () => {
 
   const line = '[4676635a]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('constant.numeric.dcbor');
 });
 
@@ -249,7 +249,7 @@ test('tokenize UR literals', async () => {
 
   const line = 'ur:envelope/abcd';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('constant.other.ur.dcbor');
 });
 
@@ -265,7 +265,7 @@ test('tokenize keywords', async () => {
 
   const line = 'ELIDED ENCRYPTED COMPRESSED';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('keyword.other.envcase.dcbor');
 });
 
@@ -281,7 +281,7 @@ test('tokenize special numeric keywords', async () => {
 
   const line = '[Infinity, -Infinity, NaN]';
   const { tokens } = grammar.tokenizeLine(line, INITIAL);
-  const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes = tokens.flatMap(t => t.scopes);
   expect(scopes).toContain('constant.numeric.special.dcbor');
 });
 
@@ -304,13 +304,13 @@ test('tokenize multiline prefixed string literals', async () => {
 
   // First line should have the beginning of a multiline prefixed string
   const line1Result = grammar.tokenizeLine(lines[0], INITIAL);
-  const scopes1 = line1Result.tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopes1 = line1Result.tokens.flatMap(t => t.scopes);
   expect(scopes1).toContain('string.quoted.prefixed.multiline.dcbor');
   expect(scopes1).toContain('comment.block.inline.dcbor');
 
   // Last line should have the end of the multiline prefixed string
   const lastLineResult = grammar.tokenizeLine(lines[2], INITIAL);
-  const scopesLast = lastLineResult.tokens.map(t => t.scopes[t.scopes.length - 1]);
+  const scopesLast = lastLineResult.tokens.flatMap(t => t.scopes);
   expect(scopesLast).toContain('string.quoted.prefixed.multiline.dcbor');
   expect(scopesLast).toContain('comment.block.inline.dcbor');
 });
@@ -334,7 +334,7 @@ test('tokenize hexadecimal floating point with binary exponent', async () => {
 
   for (const line of examples) {
     const { tokens } = grammar.tokenizeLine(line, INITIAL);
-    const scopes = tokens.map(t => t.scopes[t.scopes.length - 1]);
+    const scopes = tokens.flatMap(t => t.scopes);
     expect(scopes).toContain('constant.numeric.hex.dcbor');
   }
 });

--- a/themes/dark_plus.json
+++ b/themes/dark_plus.json
@@ -1,0 +1,205 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark+",
+	"include": "./dark_vs.json",
+	"tokenColors": [
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal" // See https://en.cppreference.com/w/cpp/language/user_literal
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.directive.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#C586C0"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder", // placeholders in strings
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#4FC1FF",
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		}
+	],
+	"semanticTokenColors": {
+		"newOperator":"#C586C0",
+		"stringLiteral":"#ce9178",
+		"customLiteral": "#DCDCAA",
+		"numberLiteral": "#b5cea8",
+	}
+}

--- a/themes/dark_vs.json
+++ b/themes/dark_vs.json
@@ -1,0 +1,411 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark (Visual Studio)",
+	"colors": {
+		"checkbox.border": "#6B6B6B",
+		"editor.background": "#1E1E1E",
+		"editor.foreground": "#D4D4D4",
+		"editor.inactiveSelectionBackground": "#3A3D41",
+		"editorIndentGuide.background1": "#404040",
+		"editorIndentGuide.activeBackground1": "#707070",
+		"editor.selectionHighlightBackground": "#ADD6FF26",
+		"list.dropBackground": "#383B3D",
+		"activityBarBadge.background": "#007ACC",
+		"sideBarTitle.foreground": "#BBBBBB",
+		"input.placeholderForeground": "#A6A6A6",
+		"menu.background": "#252526",
+		"menu.foreground": "#CCCCCC",
+		"menu.separatorBackground": "#454545",
+		"menu.border": "#454545",
+		"menu.selectionBackground": "#0078d4",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D",
+		"ports.iconRunningProcessForeground": "#369432",
+		"sideBarSectionHeader.background": "#0000",
+		"sideBarSectionHeader.border": "#ccc3",
+		"tab.selectedBackground": "#222222",
+		"tab.selectedForeground": "#ffffffa0",
+		"tab.lastPinnedBorder": "#ccc3",
+		"list.activeSelectionIconForeground": "#FFF",
+		"terminal.inactiveSelectionBackground": "#3A3D41",
+		"widget.border": "#303031",
+		"actionBar.toggledBackground": "#383a49"
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#646695"
+			}
+		},
+		{
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.tag.css",
+				"entity.name.tag.less"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"source.css entity.other.attribute-name.class",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.parent.less",
+				"source.css entity.other.attribute-name.pseudo-class",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "punctuation.definition.quote.begin.markdown",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#6796e6"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"name": "brackets of XML/HTML tags",
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.tag",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.value",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"source.css variable",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"name": "coloring of the Java import and package identifiers",
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#d4d4d4",
+		"stringLiteral": "#ce9178",
+		"customLiteral": "#D4D4D4",
+		"numberLiteral": "#b5cea8",
+	}
+}

--- a/themes/dcbor-envelope-dark-color-theme.json
+++ b/themes/dcbor-envelope-dark-color-theme.json
@@ -1,5 +1,6 @@
 {
     "name": "dCBOR Envelope Dark Theme",
+    "include": "./dark_plus.json",
     "type": "dark",
     "colors": {},
     "tokenColors": [

--- a/themes/dcbor-envelope-light-color-theme.json
+++ b/themes/dcbor-envelope-light-color-theme.json
@@ -1,5 +1,6 @@
 {
     "name": "dCBOR Envelope Light Theme",
+    "include": "./light_plus.json",
     "type": "light",
     "colors": {},
     "tokenColors": [

--- a/themes/light_plus.json
+++ b/themes/light_plus.json
@@ -1,0 +1,207 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Light+",
+	"include": "./light_vs.json",
+	"tokenColors": [ // adds rules to the light vs rules
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal" // See https://en.cppreference.com/w/cpp/language/user_literal
+			],
+			"settings": {
+				"foreground": "#795E26"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#267f99"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"foreground": "#267f99"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"source.cpp keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.directive.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#AF00DB"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder", // placeholders in strings
+
+			],
+			"settings": {
+				"foreground": "#001080"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#0070C1",
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#001080"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#EE0000"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#EE0000"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#000000"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#AF00DB",
+		"stringLiteral": "#a31515",
+		"customLiteral": "#795E26",
+		"numberLiteral": "#098658",
+	}
+}

--- a/themes/light_vs.json
+++ b/themes/light_vs.json
@@ -1,0 +1,437 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Light (Visual Studio)",
+	"colors": {
+		"checkbox.border": "#919191",
+		"editor.background": "#FFFFFF",
+		"editor.foreground": "#000000",
+		"editor.inactiveSelectionBackground": "#E5EBF1",
+		"editorIndentGuide.background1": "#D3D3D3",
+		"editorIndentGuide.activeBackground1": "#939393",
+		"editor.selectionHighlightBackground": "#ADD6FF80",
+		"editorSuggestWidget.background": "#F3F3F3",
+		"activityBarBadge.background": "#007ACC",
+		"sideBarTitle.foreground": "#6F6F6F",
+		"list.hoverBackground": "#E8E8E8",
+		"menu.border": "#D4D4D4",
+		"input.placeholderForeground": "#767676",
+		"searchEditor.textInputBorder": "#CECECE",
+		"settings.textInputBorder": "#CECECE",
+		"settings.numberInputBorder": "#CECECE",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D",
+		"ports.iconRunningProcessForeground": "#369432",
+		"sideBarSectionHeader.background": "#0000",
+		"sideBarSectionHeader.border": "#61616130",
+		"tab.selectedForeground": "#333333b3",
+		"tab.selectedBackground": "#ffffffa5",
+		"tab.lastPinnedBorder": "#61616130",
+		"notebook.cellBorderColor": "#E8E8E8",
+		"notebook.selectedCellBackground": "#c8ddf150",
+		"statusBarItem.errorBackground": "#c72e0f",
+		"list.activeSelectionIconForeground": "#FFF",
+		"list.focusAndSelectionOutline": "#90C2F9",
+		"terminal.inactiveSelectionBackground": "#E5EBF1",
+		"widget.border": "#d4d4d4",
+		"actionBar.toggledBackground": "#dddddd",
+		"diffEditor.unchangedRegionBackground": "#f8f8f8"
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#000000ff"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#008000"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"name": "css tags in selectors, xml tags",
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "entity.name.selector",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#e50000"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"source.css entity.other.attribute-name.class",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.parent.less",
+				"source.css entity.other.attribute-name.pseudo-class",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#cd3131"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.quote.begin.markdown",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"name": "brackets of XML/HTML tags",
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": [
+				"string.comment.buffered.block.pug",
+				"string.quoted.pug",
+				"string.interpolated.pug",
+				"string.unquoted.plain.in.yaml",
+				"string.unquoted.plain.out.yaml",
+				"string.unquoted.block.yaml",
+				"string.quoted.single.yaml",
+				"string.quoted.double.xml",
+				"string.quoted.single.xml",
+				"string.unquoted.cdata.xml",
+				"string.quoted.double.html",
+				"string.quoted.single.html",
+				"string.unquoted.html",
+				"string.quoted.single.handlebars",
+				"string.quoted.double.handlebars"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"source.css variable",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#e50000"
+			}
+		},
+		{
+			"scope": [
+				"support.type.property-name.json"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"name": "coloring of the Java import and package identifiers",
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#0000ff",
+		"stringLiteral": "#a31515",
+		"customLiteral": "#000000",
+		"numberLiteral": "#098658",
+	}
+}


### PR DESCRIPTION
## Summary
- mix in VS Code's default themes so other languages still highlight
- adjust grammar scopes to fall back to standard scope names
- update tests for new scopes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855100671f08325987b4beb0f723e92